### PR TITLE
Constrain pytest to >=7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,8 @@ requirements:
     - python >=3.7
     - importlib_metadata >=3.6
     - typing_extensions >=4.4.0
+  run_constrained:
+    - pytest >=7
 
 test:
   imports:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Only pytest >=7 is compatible with typeguard as of version 3.0.0 due to this import https://github.com/agronholm/typeguard/blob/f377be389765ed0db104b41d78fce3c45e72e149/src/typeguard/_pytest_plugin.py#L6. The Config class was only exposed in pytest 7 via this PR https://github.com/pytest-dev/pytest/pull/8697/files.

I've run into issues like the following when trying to use typeguard with pytest 5.* and 6.*:
```
  File "conda/test-env/lib/python3.8/site-packages/typeguard/_pytest_plugin.py", line 6, in <module>
    from pytest import Config, Parser
ImportError: cannot import name 'Config' from 'pytest' (conda/test-env/lib/python3.8/site-packages/pytest/__init__.py)
```

We might want to consider backporting this to 3.* versions of typeguard too
